### PR TITLE
Support `$` character in .env key names

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   ],
   "scripts": {
     "lint": "eslint .",
-    "test": "npm run lint && jest  --coverage",
+    "unit-tests": "jest  --coverage",
+    "test": "npm run lint && npm run unit-tests",
     "docs": "jsdoc2md -f 'src/index.js' > doc/api.md"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,14 +16,16 @@
     "lint": "eslint .",
     "unit-tests": "jest  --coverage",
     "test": "npm run lint && npm run unit-tests",
-    "docs": "jsdoc2md -f 'src/index.js' > doc/api.md"
+    "docs": "jsdoc2md -f 'src/index.js' > doc/api.md",
+    "postinstall": "patch-package"
   },
   "dependencies": {
     "debug": "^4.1.1",
     "deepmerge": "^4.0.0",
     "dotenv": "^8.0.0",
     "hjson": "^3.1.2",
-    "js-yaml": "^3.13.0"
+    "js-yaml": "^3.13.0",
+    "patch-package": "^6.2.0"
   },
   "devDependencies": {
     "babel-runtime": "^6.26.0",

--- a/patches/dotenv+8.2.0.patch
+++ b/patches/dotenv+8.2.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/dotenv/lib/main.js b/node_modules/dotenv/lib/main.js
+index e6c591c..f391cb5 100644
+--- a/node_modules/dotenv/lib/main.js
++++ b/node_modules/dotenv/lib/main.js
+@@ -29,7 +29,7 @@ function log (message /*: string */) {
+ }
+ 
+ const NEWLINE = '\n'
+-const RE_INI_KEY_VAL = /^\s*([\w.-]+)\s*=\s*(.*)?\s*$/
++const RE_INI_KEY_VAL = /^\s*([\w.-\\$]+)\s*=\s*(.*)?\s*$/
+ const RE_NEWLINES = /\\n/g
+ const NEWLINES_MATCH = /\n|\r|\r\n/
+ 

--- a/test/__fixtures__/dollarsign
+++ b/test/__fixtures__/dollarsign
@@ -1,0 +1,1 @@
+AIO_$foo=bar

--- a/test/__fixtures__/dollarsign
+++ b/test/__fixtures__/dollarsign
@@ -1,1 +1,4 @@
 AIO_$foo=bar
+$foo=baz
+foo$=caz
+

--- a/test/dotenv.js
+++ b/test/dotenv.js
@@ -124,6 +124,8 @@ describe('parse', () => {
     fs.writeFileSync('/project/.env', fixtureFile('dollarsign'))
     dotenv()
     expect(process.env.AIO_$foo).toEqual('bar')
+    expect(process.env.$foo).toEqual('baz')
+    expect(process.env.foo$).toEqual('caz')
   })
 
   test('comment', () => {

--- a/test/dotenv.js
+++ b/test/dotenv.js
@@ -120,6 +120,12 @@ describe('parse', () => {
     expect(process.env.D).toEqual('')
   })
 
+  test('dollar sign', () => {
+    fs.writeFileSync('/project/.env', fixtureFile('dollarsign'))
+    dotenv()
+    expect(process.env.AIO_$foo).toEqual('bar')
+  })
+
   test('comment', () => {
     fs.writeFileSync('/project/.env', fixtureFile('comment'))
     dotenv()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Support `$` character in .env key names.

## Motivation and Context

This is for the `aio-cli-plugin-app`, which needs this support for the new `aio-cli-plugin-auth` plugin, which uses the `$ims` config key. The app plugin imports a downloadable config which is separated into `.aio` and `.env` key files. The `.env` file may contain an `AIO_$ims_???` entry which is mapped into the consolidated config.

This patch adds support for this `$` prefixed key, which is essential for auth.

## How Has This Been Tested?

npm test

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
