### PR TITLE
fix: underscores in .env key names are not replaced globally, only first reference is replaced (during un-escape)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/aio-lib-core-config",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Adobe I/O Configuration Module",
   "main": "./src/index.js",
   "repository": "https://github.com/adobe/aio-lib-core-config",

--- a/src/Config.js
+++ b/src/Config.js
@@ -54,7 +54,7 @@ class Config {
         const newKey = match[1].toLowerCase()
           .split(/(?<!_)_(?!_)/)
           .join('.')
-          .replace('__', '_')
+          .replace(/__/gi, '_')
         envKeys.push(newKey)
         this.envs = setValue(newKey, process.env[key], this.envs)
       }

--- a/test/Config.js
+++ b/test/Config.js
@@ -161,8 +161,9 @@ describe('Config', () => {
       process.env.AIO_PGB_AUTH__TOKEN = 12
       process.env.AIO_RUNTIME = 12
       process.env.AIOBAD = 12
+      process.env.AIO_my__config__value = 12
       const config = new Config()
-      expect(config.get()).toEqual({ pgb: { auth_token: '12' }, runtime: '12' })
+      expect(config.get()).toEqual({ pgb: { auth_token: '12' }, runtime: '12', my_config_value: '12' })
     })
 
     test('should override local and global settings', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Closes #29

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
