### PR TITLE
Read config key from env AIO_CONFIG_KEY

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -37,10 +37,13 @@ const readFile = (file) => {
 class Config {
   reload() {
     dotenv(true)
-
+    // get the env var and use it as the config root key
+    // this could be aio or wxp or whatever
+    const configRootKey = process.env.AIO_CONFIG_KEY || 'aio'
     const configBasePath = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config')
-    this.global = { file: process.env.AIO_CONFIG_FILE || path.join(configBasePath, 'aio') }
-    this.local = { file: path.join(process.cwd(), '.aio') }
+
+    this.global = { file: process.env.AIO_CONFIG_FILE || path.join(configBasePath, configRootKey) }
+    this.local = { file: path.join(process.cwd(), `.${configRootKey}`) }
 
     this.global = { ...this.global, ...readFile(this.global.file) }
     this.local = { ...this.local, ...readFile(this.local.file) }
@@ -49,8 +52,11 @@ class Config {
 
     const envKeys = []
     for (const key in process.env) {
-      const match = key.match(/^AIO_(.+)/i)
+      const dynamicKey = new RegExp(`^${configRootKey.toUpperCase()}_(.+)`, 'i')
+      const match = key.match(dynamicKey)
       if (match) {
+        // join single _ with .
+        // replace double __ with _
         const newKey = match[1].toLowerCase()
           .split(/(?<!_)_(?!_)/)
           .join('.')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This is an alternative approach to #62
Instead of depending on an executable file name to be used as the key, we allow the use of an environment variable `AIO_CONFIG_KEY` to define the key.
Alternative CLIs can use an init hook to set this value before other plugins load the config.
AIO_CONFIG_KEY is used in the following ways:

- used to load global config ex. `~/.config/aio`
- used to read a local config ex. `.aio`
- used as a prefix for environment variables ex. `AIO_*`

A very simple hook attached to an alt cli might look like this:
```
module.exports = async function (opts) {
  process.env.AIO_CONFIG_KEY = 'wxp'
  // alternatively, it is also possible to derive the root key from the package.json
  // const pjson = opts.config?.pjson
}
```


## Related Issue

#62 


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
AIO_CONFIG_KEY=adp ADP_BOO=scary aio config get boo
scary
```

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
